### PR TITLE
Remove opinionated lock on golang

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ supports 'windows'
 
 depends 'chef-vault'
 depends 'chocolatey'
-depends 'golang', '~> 1.4'
+depends 'golang'
 depends 'firewall', '~> 1.6'
 depends 'libartifact', '~> 1.3'
 depends 'poise', '~> 2.2'


### PR DESCRIPTION
Hi @johnbellone,

The lock on `golang` is too opinionated, folks should be able to lock themselves (or default to unlocked) in my opinion.

Thanks in advance
